### PR TITLE
Checkout licsar_proc during workflow, rather than using submodules

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,13 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
+    - name: Checkout licsar_proc
+      uses: actions/checkout@master
+      with:
+        repository: comet-licsar/licsar_proc
+        path: licsar_proc
+        fetch-depth: 0
+        submodules: true
     - name: Build and Commit
       uses: sphinx-notes/pages@v2
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "licsar_proc"]
-	path = licsar_proc
-	url = https://github.com/comet-licsar/licsar_proc.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # comet-licsar
- docs etc.
+
+docs etc.


### PR DESCRIPTION
These changes should cause the licsar_proc repository to be cloned as part of the post commit workflow, rather than using subnodules, so the latest version is always retrieved.