### PR TITLE
Autodoc updates

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -32,6 +32,7 @@ email = 'cemac-support@leeds.ac.uk'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
     'sphinx.ext.githubpages'
 ]
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../licsar_proc/python/LiCSAR_lib'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # Import datetime for date information:
 import datetime

--- a/source/conf.py
+++ b/source/conf.py
@@ -68,3 +68,9 @@ latex_elements = {
     'preamble': f'\\usepackage{{customtitle}}\n\\newcommand\\email{{{email}}}',
     'maketitle': '\\customtitle'
 }
+
+# Mock imports for autodoc building:
+autodoc_mock_imports = [
+    'astropy', 'cv2', 'matplotlib', 'numpy', 'osgeo', 'pandas', 'rioxarray',
+    'scipy', 'sklearn', 'xarray'
+]

--- a/source/conf.py
+++ b/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../licsar_proc/python/LiCSAR_lib'))
 
 # Import datetime for date information:
 import datetime


### PR DESCRIPTION
Changes to conf.py for autodoc.

The Python path for Sphinx is adjusted to include the root of this repository, which will include copies of other reposotiries (e.g. licsar_proc) buring the Sphinx build.

The autodoc extension is enabled.

Various additional libraries are defined in the `autodoc_mock_imports` setting, so that these are not required to be installed for documentation building.